### PR TITLE
fix: utilize Google API key with new api endpoint

### DIFF
--- a/src/translators/engines/google.ts
+++ b/src/translators/engines/google.ts
@@ -22,7 +22,7 @@ export default class GoogleTranslate extends TranslateEngine {
     const { data } = await axios({
       method: 'GET',
       url: key
-        ? `${this.apiRootIfUserSuppliedKey}/language/translate/v2?key=${key}&q=${encodeURI(options.text)}${slugs.from}${slugs.to}&alt=json`
+        ? `${this.apiRootIfUserSuppliedKey}/language/translate/v2?key=${key}&q=${encodeURI(options.text)}${slugs.from}${slugs.to}&alt=json&format=text`
         : `${this.apiRoot}/translate_a/single?client=gtx&sl=${from}&tl=${to}&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q=${encodeURI(options.text)}`,
     })
 

--- a/src/translators/engines/google.ts
+++ b/src/translators/engines/google.ts
@@ -5,6 +5,7 @@ import { Config } from '~/core'
 export default class GoogleTranslate extends TranslateEngine {
   link = 'https://translate.google.com'
   apiRoot = 'https://translate.googleapis.com'
+  apiRootIfUserSuppliedKey = 'https://translation.googleapis.com'
 
   async translate(options: TranslateOptions) {
     const {
@@ -13,20 +14,18 @@ export default class GoogleTranslate extends TranslateEngine {
     } = options
 
     const key = Config.googleApiKey
-    const headers = key
-      ? { Authorization: `Bearer ${key}` }
-      : undefined
 
     const { data } = await axios({
       method: 'GET',
-      url: `${this.apiRoot}/translate_a/single?client=gtx&sl=${from}&tl=${to}&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q=${encodeURI(options.text)}`,
-      headers,
+      url: key
+        ? `${this.apiRootIfUserSuppliedKey}/language/translate/v2?key=${key}&q=${encodeURI(options.text)}&source=${from}&target=${to}&alt=json`
+        : `${this.apiRoot}/translate_a/single?client=gtx&sl=${from}&tl=${to}&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q=${encodeURI(options.text)}`,
     })
 
-    return this.transform(data, options)
+    return this.transform(data, options, !!key)
   }
 
-  transform(response: any, options: TranslateOptions): TranslateResult {
+  transform(response: any, options: TranslateOptions, apiKeySuppliedByUser: boolean): TranslateResult {
     const {
       text,
       to = 'auto',
@@ -40,25 +39,38 @@ export default class GoogleTranslate extends TranslateEngine {
       linkToResult: `${this.link}/#auto/${to}/${text}`,
     }
 
-    // 尝试获取详细释义
-    try {
-      const d: string[] = []
-      response.dict.forEach((v: any) => {
-        d.push(`${v.pos}：${(v.terms.slice(0, 3) || []).join(',')}`)
-      })
-      r.detailed = d
+    if (apiKeySuppliedByUser) {
+      try {
+        const result: string[] = []
+        response.data.translations.forEach((v: any) => {
+          result.push(v.translatedText)
+        })
+        r.result = result
+      }
+      catch (e) {}
     }
-    catch (e) {}
 
-    // 尝试取得翻译结果
-    try {
-      const result: string[] = []
-      response.sentences.forEach((v: any) => {
-        result.push(v.trans)
-      })
-      r.result = result
+    else {
+      // 尝试获取详细释义
+      try {
+        const detailed: string[] = []
+        response.dict.forEach((v: any) => {
+          detailed.push(`${v.pos}：${(v.terms.slice(0, 3) || []).join(',')}`)
+        })
+        r.detailed = detailed
+      }
+      catch (e) {}
+
+      // 尝试取得翻译结果
+      try {
+        const result: string[] = []
+        response.sentences.forEach((v: any) => {
+          result.push(v.trans)
+        })
+        r.result = result
+      }
+      catch (e) {}
     }
-    catch (e) {}
 
     if (!r.detailed && !r.result)
       r.error = new Error('No result')

--- a/src/translators/engines/google.ts
+++ b/src/translators/engines/google.ts
@@ -14,11 +14,15 @@ export default class GoogleTranslate extends TranslateEngine {
     } = options
 
     const key = Config.googleApiKey
+    const slugs = {
+      from: from === 'auto' || !from ? '' : `&source=${from}`,
+      to: to === 'auto' || !to ? '' : `&target=${to}`,
+    }
 
     const { data } = await axios({
       method: 'GET',
       url: key
-        ? `${this.apiRootIfUserSuppliedKey}/language/translate/v2?key=${key}&q=${encodeURI(options.text)}&source=${from}&target=${to}&alt=json`
+        ? `${this.apiRootIfUserSuppliedKey}/language/translate/v2?key=${key}&q=${encodeURI(options.text)}${slugs.from}${slugs.to}&alt=json`
         : `${this.apiRoot}/translate_a/single?client=gtx&sl=${from}&tl=${to}&hl=zh-CN&dt=t&dt=bd&ie=UTF-8&oe=UTF-8&dj=1&source=icon&q=${encodeURI(options.text)}`,
     })
 


### PR DESCRIPTION
This is the proposed fix mentioned in https://github.com/lokalise/i18n-ally/issues/531.

The Google API either wants you to use a permanent API key (which works with this solution) or get access tokens which expire + being OAuthed to Google Cloud to work with POST requests.

This will check if the user supplied a Google API key and use the correct endpoint/GET-request. If a key was supplied it will also use different parsing to accommodate the new response structure.

This will leave the behaviour as-is if the user doesn't supply a key.

I am not sure how this will work if a user in China supplies an API-key as I expect it to use the `apiRootIfUserSuppliedKey` which might be blocked?