### PR TITLE
feat: allow using deepl api free plan

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -34,6 +34,7 @@
   "config.annotations": "Enable the inline annotations.",
   "config.deepl_api_key": "API key to use DeepL translate engine",
   "config.deepl_log": "Show DeepL engine debug logs",
+  "config.deepl_use_free_api": "Use DeepL API Free plan",
   "config.default_namespace": "Global default namespace",
   "config.deprecated": "Deprecated. Use \"i18n-ally.\" prefix instead.",
   "config.derived_keys": "Rules to mark derived keys in the usage report",

--- a/locales/en.json
+++ b/locales/en.json
@@ -34,7 +34,7 @@
   "config.annotations": "Enable the inline annotations.",
   "config.deepl_api_key": "API key to use DeepL translate engine",
   "config.deepl_log": "Show DeepL engine debug logs",
-  "config.deepl_use_free_api": "Use DeepL API Free plan",
+  "config.deepl_use_free_api_entry": "Use DeepL Free API entry point",
   "config.default_namespace": "Global default namespace",
   "config.deprecated": "Deprecated. Use \"i18n-ally.\" prefix instead.",
   "config.derived_keys": "Rules to mark derived keys in the usage report",

--- a/package.json
+++ b/package.json
@@ -941,10 +941,10 @@
           "default": false,
           "description": "%config.deepl_log%"
         },
-        "i18n-ally.translate.deepl.useFreeApi": {
+        "i18n-ally.translate.deepl.useFreeApiEntry": {
           "type": "boolean",
           "default": false,
-          "description": "%config.deepl_use_free_api%"
+          "description": "%config.deepl_use_free_api_entry%"
         },
         "i18n-ally.usage.scanningIgnore": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -941,6 +941,11 @@
           "default": false,
           "description": "%config.deepl_log%"
         },
+        "i18n-ally.translate.deepl.useFreeApi": {
+          "type": "boolean",
+          "default": false,
+          "description": "%config.deepl_use_free_api%"
+        },
         "i18n-ally.usage.scanningIgnore": {
           "type": "array",
           "items": {

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -489,6 +489,10 @@ export class Config {
     return this.getConfig<string | null | undefined>('translate.deepl.apiKey')
   }
 
+  static get deeplUseFreeApi() {
+    return this.getConfig<boolean>('translate.deepl.useFreeApi')
+  }
+
   static get deeplLog(): Boolean {
     return !!this.getConfig('translate.deepl.enableLog')
   }

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -489,8 +489,8 @@ export class Config {
     return this.getConfig<string | null | undefined>('translate.deepl.apiKey')
   }
 
-  static get deeplUseFreeApi() {
-    return this.getConfig<boolean>('translate.deepl.useFreeApi')
+  static get deeplUseFreeApiEntry() {
+    return this.getConfig<boolean>('translate.deepl.useFreeApiEntry')
   }
 
   static get deeplLog(): Boolean {

--- a/src/translators/engines/deepl.ts
+++ b/src/translators/engines/deepl.ts
@@ -22,7 +22,7 @@ interface DeepLTranslateRes {
 const deepl = axios.create({})
 
 deepl.interceptors.request.use((req) => {
-  req.baseURL = Config.deeplUseFreeApi
+  req.baseURL = Config.deeplUseFreeApiEntry
     ? 'https://api-free.deepl.com/v2'
     : 'https://api.deepl.com/v2'
 

--- a/src/translators/engines/deepl.ts
+++ b/src/translators/engines/deepl.ts
@@ -19,11 +19,13 @@ interface DeepLTranslateRes {
   translations: DeepLTranslate[]
 }
 
-const deepl = axios.create({
-  baseURL: 'https://api.deepl.com/v2',
-})
+const deepl = axios.create({})
 
 deepl.interceptors.request.use((req) => {
+  req.baseURL = Config.deeplUseFreeApi
+    ? 'https://api-free.deepl.com/v2'
+    : 'https://api.deepl.com/v2'
+
   req.params = {
     auth_key: Config.deeplApiKey,
   }


### PR DESCRIPTION
DeepL has a free api as seen [here](https://www.deepl.com/en/docs-api/). The key for free api does not work on pro api and vice-versa.

This PR adds a `i18n-ally.translate.deepl.useFreeApi` boolean option to use that API instead of PRO plan. 