### PR TITLE
Improve Google Cloud protected API endpoint usage

### DIFF
--- a/src/translators/engines/google.ts
+++ b/src/translators/engines/google.ts
@@ -8,12 +8,18 @@ export default class GoogleTranslate extends TranslateEngine {
   apiRootIfUserSuppliedKey = 'https://translation.googleapis.com'
 
   async translate(options: TranslateOptions) {
-    const {
+    let {
       from = 'auto',
       to = 'auto',
     } = options
 
     const key = Config.googleApiKey
+
+    if (key) {
+      from = this.convertToSupportedLocalesForGoogleCloud(from);
+      to = this.convertToSupportedLocalesForGoogleCloud(to);
+    }
+
     const slugs = {
       from: from === 'auto' || !from ? '' : `&source=${from}`,
       to: to === 'auto' || !to ? '' : `&target=${to}`,
@@ -27,6 +33,14 @@ export default class GoogleTranslate extends TranslateEngine {
     })
 
     return this.transform(data, options, !!key)
+  }
+
+  convertToSupportedLocalesForGoogleCloud(locale: string): string {
+    const longSupportedLocales = ["ceb", "zh-TW", "haw", "hmn", "auto"];
+    if (locale && longSupportedLocales.indexOf(locale) === -1) {
+      locale = locale.substring(0, 2);
+    }
+    return locale;
   }
 
   transform(response: any, options: TranslateOptions, apiKeySuppliedByUser: boolean): TranslateResult {


### PR DESCRIPTION
The protected API endpoint is a bit more specific with what it supports (compared to the free one).

This will hopefully improve user experience with automated translations by only using the first part (fr instead of fr-Fr) when providing a key.

By doing this you will get a successful response, without this you will get a 400 response.

This PR was made due to comments in https://github.com/lokalise/i18n-ally/issues/531 where two users noticed the 400 behavior.