### PR TITLE
Reduce vscode package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "@babel/parser": "^7.14.3",
     "@babel/traverse": "^7.14.2",
-    "@types/string-similarity": "^4.0.0",
     "bcp-47-normalize": "^2.0.1",
     "change-case": "^4.1.2",
     "consolidate": "^0.16.0",
@@ -67,8 +66,6 @@
     "qs": "^6.10.1",
     "semver": "^7.3.5",
     "string-similarity": "^4.0.4",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.2.4",
     "vue-i18n-locale-message": "^1.0.0",
     "vue-template-compiler": "^2.6.14",
     "yaml": "^1.10.2"
@@ -93,6 +90,7 @@
     "@types/node": "^15.6.1",
     "@types/qs": "^6.9.6",
     "@types/semver": "^7.3.6",
+    "@types/string-similarity": "^4.0.0",
     "@types/vscode": "^1.52.0",
     "@types/webpack": "^4.41.26",
     "axios": "^0.21.1",
@@ -119,6 +117,8 @@
     "stylus": "^0.54.8",
     "ts-loader": "^8.1.0",
     "ts-mocha": "^8.0.0",
+    "ts-node": "^9.1.1",
+    "typescript": "^4.2.4",
     "tsconfig-paths-webpack-plugin": "^3.5.1",
     "vscode-test": "^1.5.2",
     "vue": "^2.6.14",


### PR DESCRIPTION
Hi,

Somehow I stumbled upon question why my VSCode extensions folder is so big and I found that you have (probably by mistake) added `typescript`, `ts-node` and one `@types/` packages to `dependencies` instead of `devDependencies` in `package.json`.

This resulted in an additional `50MB` of package size.

I fixed that, tested it briefly and it looks that this have no impact on the production package itself and it works the same in VSCode. Additional testing is advised as I am not a long-term contributor in this project.