### PR TITLE
fix: i18next greedy namespace regex

### DIFF
--- a/src/frameworks/i18next.ts
+++ b/src/frameworks/i18next.ts
@@ -81,7 +81,7 @@ class I18nextFramework extends Framework {
 
     const ranges: ScopeRange[] = []
     const text = document.getText()
-    const reg = /useTranslation\(\s*\[?\s*['"`](.*)['"`]/g
+    const reg = /useTranslation\(\s*\[?\s*['"`](.*?)['"`]/g
 
     for (const match of text.matchAll(reg)) {
       if (match?.index == null)


### PR DESCRIPTION
It seems this regex was incorrect when using multiple namespaces with react-i18next. For example, if our hook was:
```
useTranslation(['foo', 'bar'])
```
The regex matched `foo', 'bar` because it was greedy. With this pull request, it correctly matches `foo` as the default namespace.