### PR TITLE
Fix file reloading on write

### DIFF
--- a/src/core/loaders/LocaleLoader.ts
+++ b/src/core/loaders/LocaleLoader.ts
@@ -319,7 +319,10 @@ export class LocaleLoader extends Loader {
         await parser.save(filepath, processed, Config.sortKeys)
 
         if (this._files[filepath]) {
-          this._files[filepath].value = modified
+          const value = Config.disablePathParsing
+            ? modified
+            : unflatten(modified)
+          this._files[filepath].value = value
           this._files[filepath].mtime = this.getMtime(filepath)
         }
       }


### PR DESCRIPTION
This syncs the logic of populating files cache to match the one from `loadFile` function. `unflatten()` call was missing and causing cache to be populated with wrong object structure.

Fixes #555, see comment for more details: https://github.com/lokalise/i18n-ally/issues/555#issuecomment-937570752