### PR TITLE
add option to sorting message by a locale's order

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,7 @@
   "i18n-ally.keystyle": "flat",
   "i18n-ally.preferredDelimiter": "_",
   "i18n-ally.sortKeys": true,
+  "i18n-ally.sortCompare": "binary",
   "i18n-ally.keepFulfilled": true,
   "i18n-ally.translate.promptSource": true,
   "i18n-ally.pathMatcher": "{locale}.json",

--- a/locales/en.json
+++ b/locales/en.json
@@ -84,6 +84,8 @@
   "config.review_username": "Username for reviewing",
   "config.show_flags": "Show flags along with locale codes",
   "config.sort_keys": "Sort keys when saving to JSON/YAML",
+  "config.sort_compare": "Strategy for sorting keys.",
+  "config.sort_locale": "Locale to with if locale sort is used (will use the file's own locale if not specified)",
   "config.source_language": "Source language for machine translation",
   "config.tab_style": "Tab style for locale files",
   "config.target_picking_strategy": "Strategy dealing with more than one locale files were found.",

--- a/package.json
+++ b/package.json
@@ -864,6 +864,19 @@
           "default": false,
           "description": "%config.sort_keys%"
         },
+        "i18n-ally.sortCompare": {
+          "type": "string",
+          "enum": [
+            "binary",
+            "locale"
+          ],
+          "default": "binary",
+          "description": "%config.sort_compare%"
+        },
+        "i18n-ally.sortLocale": {
+          "type": "string",
+          "description": "%config.sort_locale%"
+        },
         "i18n-ally.preferredDelimiter": {
           "type": "string",
           "default": "-",

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -4,7 +4,7 @@ import { workspace, extensions, ExtensionContext, commands, ConfigurationScope, 
 import { trimEnd, uniq } from 'lodash'
 import { TagSystems } from '../tagSystems'
 import { EXT_NAMESPACE, EXT_ID, EXT_LEGACY_NAMESPACE, KEY_REG_DEFAULT, KEY_REG_ALL, DEFAULT_LOCALE_COUNTRY_MAP } from '../meta'
-import { KeyStyle, DirStructureAuto, TargetPickingStrategy } from '.'
+import { KeyStyle, DirStructureAuto, SortCompare, TargetPickingStrategy } from '.'
 import i18n from '~/i18n'
 import { CaseStyles } from '~/utils/changeCase'
 import { ExtractionBabelOptions, ExtractionHTMLOptions } from '~/extraction/parsers/options'
@@ -174,6 +174,14 @@ export class Config {
 
   static get sortKeys(): boolean {
     return this.getConfig<boolean>('sortKeys') || false
+  }
+
+  static get sortCompare(): SortCompare {
+    return this.getConfig<SortCompare>('sortCompare') || 'binary'
+  }
+
+  static get sortLocale(): string | undefined{
+    return this.getConfig<string>('sortLocale')
   }
 
   static get readonly(): boolean {

--- a/src/core/loaders/LocaleLoader.ts
+++ b/src/core/loaders/LocaleLoader.ts
@@ -11,7 +11,7 @@ import { AllyError, ErrorType } from '../Errors'
 import { Analyst, Global, Config } from '..'
 import { Telemetry, TelemetryKey } from '../Telemetry'
 import { Loader } from './Loader'
-import { ReplaceLocale, Log, applyPendingToObject, unflatten, NodeHelper, getCache, setCache } from '~/utils'
+import { ReplaceLocale, Log, applyPendingToObject, unflatten, NodeHelper, getCache, setCache, getLocaleCompare } from '~/utils'
 import i18n from '~/i18n'
 
 const THROTTLE_DELAY = 1500
@@ -316,7 +316,10 @@ export class LocaleLoader extends Loader {
         const processingContext = { locale, targetFile: filepath }
         const processed = this.deprocessData(modified, processingContext)
 
-        await parser.save(filepath, processed, Config.sortKeys)
+        const compare = Config.sortCompare === 'locale'
+          ? getLocaleCompare(Config.sortLocale, locale)
+          : undefined
+        await parser.save(filepath, processed, Config.sortKeys, compare)
 
         if (this._files[filepath]) {
           this._files[filepath].value = modified

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,6 +77,8 @@ export interface NodeOptions {
 export type DirStructureAuto = 'auto' | 'file' | 'dir'
 export type DirStructure = 'file' | 'dir'
 
+export type SortCompare = 'binary' | 'locale'
+
 export interface Coverage {
   locale: string
   translated: number

--- a/src/parsers/base.ts
+++ b/src/parsers/base.ts
@@ -36,14 +36,14 @@ export abstract class Parser {
     return await this.parse(raw)
   }
 
-  async save(filepath: string, object: object, sort: boolean) {
-    const text = await this.dump(object, sort)
+  async save(filepath: string, object: object, sort: boolean, compare: ((x: string, y: string) => number) | undefined) {
+    const text = await this.dump(object, sort, compare)
     await File.write(filepath, text)
   }
 
   abstract parse(text: string): Promise<object>
 
-  abstract dump(object: object, sort: boolean): Promise<string>
+  abstract dump(object: object, sort: boolean, compare: ((x: string, y: string) => number) | undefined): Promise<string>
 
   parseAST(text: string): KeyInDocument[] {
     return []

--- a/src/parsers/json.ts
+++ b/src/parsers/json.ts
@@ -16,11 +16,11 @@ export class JsonParser extends Parser {
     return JSON.parse(text)
   }
 
-  async dump(object: object, sort: boolean) {
+  async dump(object: object, sort: boolean, compare: ((x: string, y: string) => number) | undefined) {
     const indent = this.options.tab === '\t' ? this.options.tab : this.options.indent
 
     if (sort)
-      return `${SortedStringify(object, { space: indent })}\n`
+      return `${SortedStringify(object, { space: indent, cmp: compare ? (a, b) => compare(a.key, b.key) : undefined })}\n`
     else
       return `${JSON.stringify(object, null, indent)}\n`
   }

--- a/src/parsers/yaml.ts
+++ b/src/parsers/yaml.ts
@@ -15,11 +15,11 @@ export class YamlParser extends Parser {
     return YAML.load(text, Config.parserOptions?.yaml?.load) as Object
   }
 
-  async dump(object: object, sort: boolean) {
+  async dump(object: object, sort: boolean, compare: ((x: string, y: string) => number) | undefined) {
     object = JSON.parse(JSON.stringify(object))
     return YAML.dump(object, {
       indent: this.options.indent,
-      sortKeys: sort,
+      sortKeys: sort ? (compare ?? true) : false,
       ...Config.parserOptions?.yaml?.dump,
     })
   }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -96,3 +96,14 @@ export function abbreviateNumber(value: number): string {
   result += suffixes[suffixNum]
   return result
 }
+
+/**
+ * Get a locale aware comparison function
+ */
+export function getLocaleCompare(
+  sortLocaleSetting: string | undefined,
+  fileLocale: string
+): (x: string, y: string) => number {
+  const sortLocale = sortLocaleSetting ? sortLocaleSetting : fileLocale;
+  return new Intl.Collator(sortLocale).compare;
+}


### PR DESCRIPTION
i18n Ally uses a binary sort when it sorts keys. This is unexpected ("O" is sorted before "o") and doesn't take differences in how languages sort things into account.

This change adds two config settings `sortCompare` and `sortLocale`.

- By default `sortCompare` is `binary` which is the current behaviour
- You can set `sortCompare` to `locale` and set `sortLocale` to `en` and keys will be ordered according to English rules for sorting text.
- Alternatively you can set `sortCompare` to `locale` and leave `sortLocale` unspecified and each messages file will be sorted according to its own locale (e.g. `en/common.json` will be sorted using English order, while `es/common.json` will be sorted according to Spanish order).

Fixes #702