### PR TITLE
add keyPath support for react-i18n-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -776,6 +776,11 @@
           "default": true,
           "description": "%config.annotation_in_place%"
         },
+        "i18n-ally.enableKeyPrefix": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable keyPrefix parsing for react-i18n-next"
+        },
         "i18n-ally.annotationMaxLength": {
           "type": "number",
           "default": 40,

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -28,6 +28,7 @@ export class Config {
     'ignoreFiles',
     'parserOptions',
     'parsers.extendFileExtensions',
+    'enableKeyPrefix',
   ]
 
   static readonly refreshConfigs = [
@@ -558,5 +559,9 @@ export class Config {
 
   static get telemetry(): boolean {
     return workspace.getConfiguration().get('telemetry.enableTelemetry') as boolean
+  }
+
+  static get enableKeyPrefix(): boolean {
+    return !!this.getConfig('enableKeyPrefix')
   }
 }

--- a/src/core/KeyDetector.ts
+++ b/src/core/KeyDetector.ts
@@ -21,8 +21,10 @@ export class KeyDetector {
 
     for (const reg of regs) {
       (text.match(reg) || [])
-        .forEach(key =>
-          keys.add(key.replace(reg, '$1')),
+        .forEach((rawKey) => {
+          const key = Config.enableKeyPrefix ? detectedKey(rawKey.replace(reg, '$1'), text) : rawKey
+          keys.add(key)
+        },
         )
     }
 
@@ -37,7 +39,8 @@ export class KeyDetector {
     for (const regex of regs) {
       const range = document.getWordRangeAtPosition(position, regex)
       if (range) {
-        const key = document.getText(range).replace(regex, '$1')
+        const rawKey = document.getText(range).replace(regex, '$1')
+        const key = Config.enableKeyPrefix ? detectedKey(rawKey, document.getText()) : rawKey
 
         if (dotEnding) {
           if (!key || key.endsWith('.'))
@@ -108,7 +111,8 @@ export class KeyDetector {
     const keys = regexFindKeys(text, regs, dotEnding, rewriteContext, scopes)
     if (filepath)
       this._get_keys_cache[filepath] = keys
-    return keys
+
+    return Config.enableKeyPrefix ? detectedKeys(keys, typeof document === 'string' ? document : document.getText()) : keys
   }
 
   static getUsages(document: TextDocument, loader?: Loader): KeyUsages | undefined {
@@ -146,9 +150,23 @@ export class KeyDetector {
 
     return {
       type,
-      keys,
+      keys: Config.enableKeyPrefix ? detectedKeys(keys, document.getText()) : keys,
       locale,
       namespace,
     }
   }
+}
+
+function detectedKey(key: string, documentText?: string): string {
+  if (!documentText) return key
+  const mathces = documentText.match(/useTranslation\(.+,\s*{\s*keyPrefix:\s*["'`](?<keyPath>.+)["'`]\s*}\s*\)/)
+
+  const keyPath = mathces?.groups?.keyPath
+  if (!keyPath) return key
+
+  return `${keyPath}.${key}`
+}
+
+export function detectedKeys<T extends {key: string}>(keys: T[], documentText?: string): T[] {
+  return keys.map(value => ({ ...value, key: detectedKey(value.key, documentText) }))
 }


### PR DESCRIPTION
Allow keyPath support for react-i18n-next `useTranslation` hook

closes #719