### PR TITLE
feat: allow using the source text as a keygen strategy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1132,7 +1132,8 @@
           "enum": [
             "slug",
             "random",
-            "empty"
+            "empty",
+            "source"
           ],
           "description": "%config.keygen_strategy%"
         },

--- a/src/core/Extract.ts
+++ b/src/core/Extract.ts
@@ -26,6 +26,9 @@ export function generateKeyFromText(text: string, filepath?: string, reuseExisti
   else if (keygenStrategy === 'empty') {
     key = ''
   }
+  else if (keygenStrategy === 'source') {
+    key = text
+  }
   else {
     text = text.replace(/\$/g, '')
     key = limax(text, { separator: Config.preferredDelimiter, tone: false })
@@ -33,7 +36,7 @@ export function generateKeyFromText(text: string, filepath?: string, reuseExisti
   }
 
   const keyPrefix = Config.keyPrefix
-  if (keyPrefix && keygenStrategy !== 'empty')
+  if (keyPrefix && keygenStrategy !== 'empty' && keygenStrategy !== 'source')
     key = keyPrefix + key
 
   if (filepath && key.includes('fileName')) {


### PR DESCRIPTION
When using source texts as the keys for translations, a useful feature is to be able to extract the source texts as is.