### PR TITLE
fix: add ftl as a parser that can be enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -847,7 +847,8 @@
               "ini",
               "po",
               "php",
-              "properties"
+              "properties",
+              "ftl"
             ]
           },
           "description": "%config.enabled_parsers%"


### PR DESCRIPTION
Hi there,

the Fluent project support has been added with the `fluent-vue` support (#651). It works well, but VS Code still issues a warning saying that `ftl`is not a valid parser. It is useful for projects that use Fluent without a specific framework or in another language (Rust).

Thanks for your time