### PR TITLE
svelte: Update usageMatchRegex

### DIFF
--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -22,7 +22,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '\\$[_t]\\([\'"`]({key})[\'"`]',
+    '\\$[_t]\\(\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {

--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -22,7 +22,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(\\$(_|t|format)|(get)\\((_|t|format)\\))\(\s*[\'"`]({key})[\'"`]',
+    '(\\$(_|t|format)|(get)\\(\s*(_|t|format)\s*\\))\(\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {

--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -22,7 +22,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(\\$(_|t|format)|(get)\\((_|t|format)\\))\(\s*[\'"`](.*)[\'"`]',
+    '(\\$(_|t|format)|(get)\\((_|t|format)\\))\(\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {

--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -22,7 +22,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '\\$[_t]\\(\s*[\'"`]({key})[\'"`]',
+    '(\\$(_|t|format)|(get)\\((_|t|format)\\))\(\s*[\'"`](.*)[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
This PR:
1) Fixes #132 for svelte
2) Adds `format` next to `_` and `t` as it's for example [exported](https://github.com/kaisermann/svelte-i18n/blob/0516bb417c4d510e5cd5d225b60cb6ad469118a5/src/runtime/index.ts#L49-L51) in the most popular at the moment i18n library for svelte
3) Adds one more svelte-specific way to handle store. (not by subscribing store via `$`, but using `get` function from `svelte`). `get(_)` usecase may appear when you are trying to get translation outside of svelte component where you can't automatically subscribe with `$`