### PR TITLE
fix: set bcp47 as default

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,6 +918,7 @@
             "legacy",
             "none"
           ],
+          "default": "bcp47",
           "description": "%config.language_tag_system%"
         },
         "i18n-ally.ignoreFiles": {


### PR DESCRIPTION
According to https://github.com/elk-zone/elk/pull/1597#issuecomment-1416037382,
the default language tag system is bcp47 but shows default as empty.