### PR TITLE
Rename `eamodio.tsl-problem-matcher` in extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
   "recommendations": [
     "dbaeumer.vscode-eslint",
     "lokalise.i18n-ally",
-    "eamodio.tsl-problem-matcher",
+    "amodio.tsl-problem-matcher",
   ]
 }


### PR DESCRIPTION
### What are you trying to accomplish?

![image](https://user-images.githubusercontent.com/1459385/234071655-858c9dc6-bafa-47a9-9c1d-ec269f077824.png)

### What approach did you choose and why?

[`eamodio.tsl-problem-matcher`](https://marketplace.visualstudio.com/items?itemName=eamodio.tsl-problem-matcher) was renamed.

### What should reviewers focus on?

🤷 

### The impact of these changes

VSCode won't complain about the missing extension.

### Testing

Visit https://marketplace.visualstudio.com/items?itemName=eamodio.tsl-problem-matcher, see that it redirects.
