### PR TITLE
Rename `johnsoncodehk.volar` extension

### DIFF
--- a/test/fixture-scripts/index.ts
+++ b/test/fixture-scripts/index.ts
@@ -77,7 +77,7 @@ async function prepareVSCode() {
   vscodeExecutablePath = await downloadAndUnzipVSCode('1.52.0')
   const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath)
 
-  spawnSync(cliPath, ['--install-extension', 'johnsoncodehk.volar'], {
+  spawnSync(cliPath, ['--install-extension', 'vue.volar'], {
     encoding: 'utf-8',
     stdio: 'inherit',
   })


### PR DESCRIPTION
### What are you trying to accomplish?

In chasing down the Vue issues plaguing the build, I looked into this error message:

```
Installing extensions...
Extension 'johnsoncodehk.volar' not found.
Make sure you use the full extension ID, including the publisher, e.g.: ms-dotnettools.csharp
Failed Installing Extensions: johnsoncodehk.volar
``` 

The extension has been renamed to `vue.volar`, as seen by [the redirect in the Marketplace](https://marketplace.visualstudio.com/items?itemName=johnsoncodehk.volar).

### What approach did you choose and why?

Simple rename. 

### What should reviewers focus on?

To be candid, I'm not sure whether/why this extension is needed at all.

### The impact of these changes

Less cluttered error log.

### Testing

```
yarn test:fixture
```