### PR TITLE
Bump version of VSCode used in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@types/semver": "^7.3.8",
     "@types/string-similarity": "^4.0.0",
     "@types/uuid": "^8.3.1",
-    "@types/vscode": "^1.52.0",
+    "@types/vscode": "^1.77.0",
     "@types/webpack": "^4.41.26",
     "axios": "^0.21.1",
     "blueimp-md5": "^2.18.0",
@@ -136,7 +136,7 @@
     "webpack-filter-warnings-plugin": "^1.2.1"
   },
   "engines": {
-    "vscode": "^1.52.0"
+    "vscode": "^1.77.3"
   },
   "categories": [
     "Other"

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -34,7 +34,7 @@ async function main() {
       await runTests({
         extensionDevelopmentPath,
         extensionTestsPath,
-        version: '1.52.0',
+        version: '1.77.3',
         launchArgs: [fixtureTargetPath, '--disable-extensions'],
       })
 

--- a/test/fixture-scripts/index.ts
+++ b/test/fixture-scripts/index.ts
@@ -74,7 +74,7 @@ async function run() {
 let vscodeExecutablePath: string
 
 async function prepareVSCode() {
-  vscodeExecutablePath = await downloadAndUnzipVSCode('1.52.0')
+  vscodeExecutablePath = await downloadAndUnzipVSCode('1.77.3')
   const cliPath = resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath)
 
   spawnSync(cliPath, ['--install-extension', 'vue.volar'], {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,10 +1293,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.1.tgz#1a32969cf8f0364b3d8c8af9cc3555b7805df14f"
   integrity sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==
 
-"@types/vscode@^1.52.0":
-  version "1.59.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.59.0.tgz#11c93f5016926126bf30b47b9ece3bd617eeef31"
-  integrity sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==
+"@types/vscode@^1.77.0":
+  version "1.77.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.77.0.tgz#f92f15a636abc9ef562f44dd8af6766aefedb445"
+  integrity sha512-MWFN5R7a33n8eJZJmdVlifjig3LWUNRrPeO1xemIcZ0ae0TEQuRc7G2xV0LUX78RZFECY1plYBn+dP/Acc3L0Q==
 
 "@types/webpack-sources@*":
   version "3.2.0"


### PR DESCRIPTION
### What are you trying to accomplish?

The i18n-ally tests are failing, since the `source.vue` files are being given the language identifier of `plaintext` ([the default for unknown languages](https://code.visualstudio.com/docs/languages/overview#_language-identifier)).

There is an override in [`test/fixtures/vue/.vscode/settings.json`](https://github.com/lokalise/i18n-ally/blob/67329128e82522dacc1d8d84fdb9f1dfdfbd79fd/test/fixtures/vue/.vscode/settings.json#L9-L11), but that is ignored unless `vue` is a known identifier.

Previously, `i18n-ally` used the `johnsoncodehk.volar` extension to add recognition of the `vue` language identifier. At some point, [`johnsoncodehk.volar` was renamed to `vue.volar`](https://github.com/lokalise/i18n-ally/pull/908). But `vue.volar` cannot be installed on VSCode v1.52.0:

```
Installing extensions...
Installing extension 'vue.volar' v1.5.4...
Server returned 404
Failed Installing Extensions: vue.volar
```

### What approach did you choose and why?

The most straightforward fix is to bump the version of VSCode used in the tests to a more modern one.

### What should reviewers focus on?

These tests wil break once again in the future if/when `vue.volar` can no longer be installed on v1.77. But I don't have a nicer solution at this time.

Other options include:

* Create an otherwise empty extension that registers the `vue` identifier, and use that
  * A minimal extension is less likely to break with a future version of VSCode. 
* Having `i18n-ally` itself register the `vue` identifier

### The impact of these changes

CI will pass again. 🙌 
