### PR TITLE
fix:Re-enable adding strings to the proper namespace

### DIFF
--- a/src/commands/manipulations/gotoKey.ts
+++ b/src/commands/manipulations/gotoKey.ts
@@ -67,8 +67,7 @@ export async function GoToKey(item?: LocaleTreeItem | CommandOptions | ProgressR
       return
 
     const text = editor.document.getText()
-    const delimiter = Global.getNamespaceDelimiter()
-    const range = parser.navigateToKey(text, NodeHelper.getPathWithoutNamespace(keypath, node, undefined, delimiter), await Global.requestKeyStyle())
+    const range = parser.navigateToKey(text, NodeHelper.getPathWithoutNamespace(keypath, node), await Global.requestKeyStyle())
 
     if (range) {
       editor.selection = new Selection(

--- a/src/core/loaders/LocaleLoader.ts
+++ b/src/core/loaders/LocaleLoader.ts
@@ -300,7 +300,6 @@ export class LocaleLoader extends Loader {
 
           if (Global.namespaceEnabled) {
             const node = this.getNodeByKey(keypath)
-
             keypath = NodeHelper.getPathWithoutNamespace(keypath, node, pending.namespace)
           }
 

--- a/src/core/loaders/LocaleLoader.ts
+++ b/src/core/loaders/LocaleLoader.ts
@@ -300,8 +300,8 @@ export class LocaleLoader extends Loader {
 
           if (Global.namespaceEnabled) {
             const node = this.getNodeByKey(keypath)
-            const delimiter = Global.getNamespaceDelimiter()
-            keypath = NodeHelper.getPathWithoutNamespace(keypath, node, pending.namespace, delimiter)
+
+            keypath = NodeHelper.getPathWithoutNamespace(keypath, node, pending.namespace)
           }
 
           modified = applyPendingToObject(


### PR DESCRIPTION
Addresses #920 

This fix reverts something that was introduced in #871.