### PR TITLE
fix(react-i18next): show sub completion items when using scoped namespace

### DIFF
--- a/src/core/KeyDetector.ts
+++ b/src/core/KeyDetector.ts
@@ -55,6 +55,16 @@ export class KeyDetector {
     return keyRange?.key
   }
 
+  static getScopedKey(document: TextDocument, position: Position)
+  {
+    const scopes = Global.enabledFrameworks.flatMap(f => f.getScopeRange(document) || [])
+    if (scopes.length > 0)
+    {
+      const offset = document.offsetAt(position)
+      return scopes.filter(s => s.start < offset && offset < s.end).map(s => s.namespace).join('.')
+    }
+  }
+
   static getKeyAndRange(document: TextDocument, position: Position, dotEnding?: boolean) {
     const { range, key } = KeyDetector.getKeyRange(document, position, dotEnding) || {}
     if (!range || !key)

--- a/src/editor/completion.ts
+++ b/src/editor/completion.ts
@@ -16,11 +16,18 @@ class CompletionProvider implements CompletionItemProvider {
     if (key === undefined)
       return
 
+    const scopedKey = KeyDetector.getScopedKey(document, position)
+
     if (!key) {
       return Object
         .values(CurrentFile.loader.keys)
         .map((key) => {
-          const item = new CompletionItem(key, CompletionItemKind.Text)
+          let resolvedKey = key
+          if (scopedKey)
+          {
+            resolvedKey = key.replace(`${scopedKey}.`, "")
+          }
+          const item = new CompletionItem(resolvedKey, CompletionItemKind.Text)
           item.detail = loader.getValueByKey(key)
           return item
         })
@@ -34,6 +41,9 @@ class CompletionProvider implements CompletionItemProvider {
       parent = parts.slice(0, -1).join('.')
 
     let node: LocaleTree | LocaleNode | undefined
+
+    if (scopedKey && key)
+      node = loader.getTreeNodeByKey([scopedKey, key].join('.'))
 
     if (!key)
       node = loader.root


### PR DESCRIPTION
This change resolve the following problems
* show auto-complete correctly using a namespace with useTranslation and other specify namespace

## Example case
Structure
```
locales/
  en/
    common.json
    login.json
  ja/
    common.json
    login.json
```
login.json
```json
{
  "emailAddress": "Email Address",
  "password": "password",
  "rememberMe": "Remember me",
  "loginButton": "Sign in",
  "socialLoginButton": "Sign in with {{provider}}"
}
```
❌
![image](https://github.com/lokalise/i18n-ally/assets/1872507/d5e6a195-cc4b-4d38-b14f-6f80f9e1e597)
✅
![image](https://github.com/lokalise/i18n-ally/assets/1872507/4de29b0c-cf19-48f0-8928-f3ed5570ec64)
