### PR TITLE
fix: error on create new key

### DIFF
--- a/src/commands/manipulations/newKey.ts
+++ b/src/commands/manipulations/newKey.ts
@@ -9,7 +9,7 @@ export async function NewKey(keypath?: string) {
 
   try {
     keypath = await window.showInputBox({
-      value: keypath || '',
+      value: typeof keypath === 'string' ? keypath : '',
       prompt: i18n.t('prompt.new_key_path'),
       ignoreFocusOut: true,
     })
@@ -61,7 +61,7 @@ export async function NewKey(keypath?: string) {
       })
     }
   }
-  catch (err) {
+  catch (err: any) {
     Log.error(err.toString())
   }
 }


### PR DESCRIPTION
fix of: #817

It seems to be vscode provide arguments a window item to command handler. So I added a validation.

In addition, there was a type error in the `catch` statement, so I added any for now.

![image](https://github.com/lokalise/i18n-ally/assets/1872507/674c923e-b532-4398-a677-f2768f13b7ee)
