### PR TITLE
fix: invalid Svelte regex

### DIFF
--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -23,7 +23,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(\\$(_|t|format)|(get)\\(\s*(_|t|format)\s*\\))\(\s*[\'"`]({key})[\'"`]',
+    '(\\$(_|t|format)|(get)\\(\\s*(_|t|format)\\s*\\))\\(\\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
Resolves #995

Fix invalid regex introduced in #826

I screwed up with with the syntax :)
For some reason you need to use double backslash `\` to escape symbols like `(` and `s`.
That differs from usual regex syntax that regexper accepts for example.