### PR TITLE
fix: Svelte regex wrong first capturing group (#1003)

### DIFF
--- a/src/frameworks/svelte.ts
+++ b/src/frameworks/svelte.ts
@@ -23,7 +23,7 @@ class SvelteFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(\\$(_|t|format)|(get)\\(\\s*(_|t|format)\\s*\\))\\(\\s*[\'"`]({key})[\'"`]',
+    '(?:\\$(?:_|t|format)|(?:get)\\(\\s*(?:_|t|format)\\s*\\))\\(\\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
Fixes #1003

According to https://github.com/lokalise/i18n-ally/wiki/Custom-Framework `({key})` in regex should be first capturing group. I did not know about this when proposed #826, #1001

I guess it would be really nice to have tests for regular expressions as it's in the core of i18n-ally.

Maybe at least we can add this info in the comment above this one?
```
// for visualize the regex, you can use https://regexper.com/
```

Knowing that you **must** capture `({key})` as the first group is much more useful than knowing how to visualize regex. If you don't mind, I would like to open another PR which will add comments about this in every framework file, because the only place where I found this is [wiki/Custom-Framework](https://github.com/lokalise/i18n-ally/wiki/Custom-Framework)
