### PR TITLE
fix: next-intl support multilines key detection (#1011)

### DIFF
--- a/src/frameworks/next-intl.ts
+++ b/src/frameworks/next-intl.ts
@@ -28,13 +28,13 @@ class NextIntlFramework extends Framework {
 
   usageMatchRegex = [
     // Basic usage
-    '[^\\w\\d]t\\([\'"`]({key})[\'"`]',
+    '[^\\w\\d]t\\s*\\(\\s*[\'"`]({key})[\'"`]',
 
     // Rich text
-    '[^\\w\\d]t\.rich\\([\'"`]({key})[\'"`]',
+    '[^\\w\\d]t\\s*\.rich\\s*\\(\\s*[\'"`]({key})[\'"`]',
 
     // Raw text
-    '[^\\w\\d]t\.raw\\([\'"`]({key})[\'"`]',
+    '[^\\w\\d]t\\s*\.raw\\s*\\(\\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
Fixes #1011

Add detection of optional line breaks and spaces for each regex in usageMatchRegex (next-intl)

<details>
<summary>Screenshots</summary>

Before:
![image](https://github.com/lokalise/i18n-ally/assets/49815452/adca82b4-9221-43c6-8fd6-25a6cafa0cf3)

After: 
![image](https://github.com/lokalise/i18n-ally/assets/49815452/93133f9b-c930-4793-afa5-50c4480f882f)

</details>