### PR TITLE
feat: Support `getTranslator` API from `next-intl`

### DIFF
--- a/examples/by-frameworks/next-intl/messages/de.json
+++ b/examples/by-frameworks/next-intl/messages/de.json
@@ -3,6 +3,9 @@
     "description": "Eine Beschreibung",
     "title": "next-intl Beispiel"
   },
+  "Metadata": {
+    "title": "Seitentitel"
+  },
   "Test": {
     "title": "Test"
   }

--- a/examples/by-frameworks/next-intl/messages/en.json
+++ b/examples/by-frameworks/next-intl/messages/en.json
@@ -3,6 +3,9 @@
     "description": "Some description",
     "title": "next-intl example"
   },
+  "Metadata": {
+    "title": "Page title"
+  },
   "Test": {
     "title": "Test"
   }

--- a/examples/by-frameworks/next-intl/next.config.js
+++ b/examples/by-frameworks/next-intl/next.config.js
@@ -1,0 +1,3 @@
+const withNextIntl = require('next-intl/plugin')()
+
+module.exports = withNextIntl()

--- a/examples/by-frameworks/next-intl/package.json
+++ b/examples/by-frameworks/next-intl/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "next": "^13.4.0",
-    "next-intl": "^2.14.1",
+    "next-intl": "3.0.0-beta.17",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/by-frameworks/next-intl/src/app/[locale]/layout.tsx
+++ b/examples/by-frameworks/next-intl/src/app/[locale]/layout.tsx
@@ -21,9 +21,6 @@ export default async function LocaleLayout({
 
   return (
     <html lang={locale}>
-      <head>
-        <title>next-intl</title>
-      </head>
       <body>
         <NextIntlClientProvider locale={locale} messages={messages}>
           {children}

--- a/examples/by-frameworks/next-intl/src/app/[locale]/page.tsx
+++ b/examples/by-frameworks/next-intl/src/app/[locale]/page.tsx
@@ -1,6 +1,14 @@
-'use client'
 
 import { useTranslations } from 'next-intl'
+import { getTranslator } from 'next-intl/server'
+
+export async function generateMetadata({ params: { locale } }) {
+  const t = await getTranslator(locale, 'Metadata')
+
+  return {
+    title: t('title'),
+  }
+}
 
 export default function IndexPage() {
   const t = useTranslations('IndexPage')
@@ -15,6 +23,8 @@ export default function IndexPage() {
       <p>{t('description')}</p>
       <Test1 />
       <Test2 />
+      <Test3 />
+      <Test4 />
     </div>
   )
 }
@@ -27,4 +37,14 @@ function Test1() {
 function Test2() {
   const t = useTranslations()
   return <p>{t('Test.title')}</p>
+}
+
+function Test3() {
+  const t = useTranslations('Test')
+  return <p>{t('title')}</p>
+}
+
+function Test4() {
+  const t = useTranslations()
+  return <p>{t('IndexPage.title')}</p>
 }

--- a/examples/by-frameworks/next-intl/src/i18n.ts
+++ b/examples/by-frameworks/next-intl/src/i18n.ts
@@ -1,0 +1,5 @@
+import { getRequestConfig } from 'next-intl/server'
+
+export default getRequestConfig(async({ locale }) => ({
+  messages: (await import(`../messages/${locale}.json`)).default,
+}))

--- a/src/frameworks/next-intl.ts
+++ b/src/frameworks/next-intl.ts
@@ -79,16 +79,16 @@ class NextIntlFramework extends Framework {
     const ranges: ScopeRange[] = []
     const text = document.getText()
 
-    // Find matches of `useTranslations`, later occurences will override
-    // previous ones (this allows for multiple components with different
+    // Find matches of `useTranslations` and `getTranslator`. Later occurences will
+    // override previous ones (this allows for multiple components with different
     // namespaces in the same file).
-    const regex = /useTranslations\(\s*(['"`](.*?)['"`])?/g
+    const regex = /(useTranslations\(\s*|getTranslator\(.*,\s*)(['"`](.*?)['"`])?/g
     let prevGlobalScope = false
     for (const match of text.matchAll(regex)) {
       if (typeof match.index !== 'number')
         continue
 
-      const namespace = match[2]
+      const namespace = match[3]
 
       // End previous scope
       if (prevGlobalScope)


### PR DESCRIPTION


See Server Components implementation of [Metadata API support](https://next-intl-docs.vercel.app/docs/environments/metadata-route-handlers#metadata-api) 

From https://github.com/lokalise/i18n-ally/issues/1011#issuecomment-1717075869