### PR TITLE
next-translate: Recognise set namespace in `useTranslation`. Support `getT` API.

### DIFF
--- a/examples/by-frameworks/next-translate/pages_/index.js
+++ b/examples/by-frameworks/next-translate/pages_/index.js
@@ -1,4 +1,3 @@
-import React from 'react'
 
 // @ts-ignore
 import Link from 'next-translate/Link'
@@ -10,9 +9,9 @@ import Header from '../components/header'
 
 // @ts-ignore
 export default function Home(props) {
-  const { t } = useTranslation()
-  const description = t('home:description')
-  const linkName = t('home:more-examples')
+  const { t } = useTranslation("home")
+  const description = t('description')
+  const linkName = t('more-examples')
 
   console.log(props)
 

--- a/examples/by-frameworks/next-translate/pages_/more-examples/gett.js
+++ b/examples/by-frameworks/next-translate/pages_/more-examples/gett.js
@@ -1,0 +1,15 @@
+import getT from "next-translate/useTranslation";
+
+export default function GetT({ locale }) {
+  const { t } = getT(locale, "more-examples");
+  const exampleWithVariable = t("example-with-variable", {
+    count: 42
+  });
+
+  return (
+    <>
+      <Header />
+      <h2>{exampleWithVariable}</h2>
+    </>
+  );
+}

--- a/src/frameworks/next-translate.ts
+++ b/src/frameworks/next-translate.ts
@@ -1,5 +1,8 @@
-import { Framework } from './base'
+import { TextDocument } from 'vscode'
+import { Framework, ScopeRange } from './base'
 import { LanguageId } from '~/utils'
+import { Config } from '~/core'
+import { extractionsParsers, DefaultExtractionRules, DefaultDynamicExtractionsRules } from '~/extraction'
 
 class NextTranslateFramework extends Framework {
   id= 'next-translate'
@@ -21,21 +24,86 @@ class NextTranslateFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '[^\\w\\d]t\\([\'"`]({key})[\'"`]',
+    '[^\\w\\d]t\\s*\\(\\s*[\'"`]({key})[\'"`]',
     '[^\\w\\d]t`({key})`',
     'Trans\\s+i18nKey=[\'"`]({key})[\'"`]',
   ]
 
+  detectHardStrings(doc: TextDocument) {
+    const lang = doc.languageId
+    const text = doc.getText()
+
+    if (lang === 'html') {
+      return extractionsParsers.html.detect(
+        text,
+        DefaultExtractionRules,
+        DefaultDynamicExtractionsRules,
+        Config.extractParserHTMLOptions,
+        // <script>
+        script => extractionsParsers.babel.detect(
+          script,
+          DefaultExtractionRules,
+          DefaultDynamicExtractionsRules,
+          Config.extractParserBabelOptions,
+        ),
+      )
+    }
+    else {
+      return extractionsParsers.babel.detect(
+        text,
+        DefaultExtractionRules,
+        DefaultDynamicExtractionsRules,
+        {},
+        (path, recordIgnore) => {
+          const callee = path.get('callee')
+          if (callee.node.name === 't' || callee.node.name === 'Trans')
+            recordIgnore(path)
+        },
+      )
+    }
+  }
+
   refactorTemplates(keypath: string) {
+    const pathWithoutNamespace = keypath.substring(keypath.indexOf('.') + 1, keypath.length)
     return [
-      `{t('${keypath}')}`,
-      `t('${keypath}')`,
-      keypath,
+      `{t('${pathWithoutNamespace}')}`,
+      `t('${pathWithoutNamespace}')`,
     ]
   }
 
-  rewriteKeys(key: string) {
-    return key.replace(/:/g, '.')
+  // useTranslation
+  getScopeRange(document: TextDocument): ScopeRange[] | undefined {
+    if (![
+      'javascript',
+      'typescript',
+      'javascriptreact',
+      'typescriptreact',
+    ].includes(document.languageId))
+      return
+
+    const ranges: ScopeRange[] = []
+    const text = document.getText()
+    const reg = /(?:useTranslation\(\s*|getT\(.*,\s*)(?:['"`](.*?)['"`])?/g
+
+    for (const match of text.matchAll(reg)) {
+      if (match?.index == null)
+        continue
+
+      // end previous scope
+      if (ranges.length)
+        ranges[ranges.length - 1].end = match.index
+
+      // start new scope if namespace provides
+      if (match[1]) {
+        ranges.push({
+          start: match.index,
+          end: text.length,
+          namespace: match[1] as string,
+        })
+      }
+    }
+
+    return ranges
   }
 
   pathMatcher() {


### PR DESCRIPTION
The current implementation of next-translate does not recognise the namespace set by the most used function `useTranslation("ns")` (https://github.com/lokalise/i18n-ally/issues/752). It also has no support for the `getT(local, "ns")`. This pull request implements both features.

I've also updated/added examples where necessary.