### PR TITLE
fix: react-intl's FormattedMessage component matching pattern being incorrect

### DIFF
--- a/src/frameworks/react-intl.ts
+++ b/src/frameworks/react-intl.ts
@@ -22,7 +22,7 @@ class ReactFramework extends Framework {
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
     // general jsx attrs
-    '[^\\w\\d](?:i18nKey=|FormattedMessage[ (]\\s*id=|t\\(\\s*)[\'"`]({key})[\'"`]',
+    '[^\\w\\d](?:i18nKey=|FormattedMessage[\\s(]\\s*id=|t\\(\\s*)[\'"`]({key})[\'"`]',
     // useIntl() hooks, https://github.com/formatjs/react-intl/blob/master/docs/API.md#useintl-hook
     '[^\\w\\d](?:formatPlural|formatNumber|formatDate|formatTime|formatHTMLMessage|formatMessage|formatRelativeTime)\\(.*?[\'"`]?id[\'"`]?:\\s*[\'"`]({key})[\'"`]',
     '<Trans>({key})<\\/Trans>',


### PR DESCRIPTION
```tsx
<FormattedMessage
  id="my.i18n.key"
  values={{value: 1}}
/>
```

In the above code, the first character after FormattedMessage is not a space or open parenthesis, but a line break, causing the match to fail
