### PR TITLE
Update next-intl.ts

### DIFF
--- a/src/frameworks/next-intl.ts
+++ b/src/frameworks/next-intl.ts
@@ -82,7 +82,7 @@ class NextIntlFramework extends Framework {
     // Find matches of `useTranslations` and `getTranslator`. Later occurences will
     // override previous ones (this allows for multiple components with different
     // namespaces in the same file).
-    const regex = /(useTranslations\(\s*|getTranslator\(.*,\s*)(['"`](.*?)['"`])?/g
+    const regex = /(useTranslations\(\s*|getTranslations\(.*,\s*)(['"`](.*?)['"`])?/g
     let prevGlobalScope = false
     for (const match of text.matchAll(regex)) {
       if (typeof match.index !== 'number')


### PR DESCRIPTION
Hi everyone,

@amannn Can you have a look about this too, currently nested keys are well extracted with `useTranslations` but not with `getTranslations` I've made some suggestions that I hope would fix the issue?

Thank you