### PR TITLE
fix/transloco: add support for prefix: to work alongside read:

### DIFF
--- a/src/frameworks/transloco.ts
+++ b/src/frameworks/transloco.ts
@@ -63,15 +63,16 @@ export default class TranslocoFramework extends Framework {
     return actualKey && scope ? `${scope}.${actualKey}` : key
   }
 
-  // support for `read` syntax
-  // https://ngneat.github.io/transloco/docs/translation-in-the-template#utilizing-the-read-input
+  // support for `read` (old, deprecated) AND `prefix` (new) syntax
+  // `read` is deprecated in favor of `prefix` and will be removed in the next major version.
+  // https://jsverse.github.io/transloco/docs/translation-in-the-template#utilizing-the-prefix-input
   getScopeRange(document: TextDocument): ScopeRange[] | undefined {
     if (document.languageId !== 'html')
       return
 
     const ranges: ScopeRange[] = []
 
-    const regex = /^.*read:\s*['"](.+?)['"].*$/
+    const regex = /^.*(?:read|prefix):\s*['"](.+?)['"].*$/
     const tagStack: string[] = []
     let stackDepth = -1
     let namespace = ''


### PR DESCRIPTION
Hello!

Since Transloco 7.1.0+ they have renamed the `read:` syntax to `prefix:`.

Link to relevant docs: https://jsverse.github.io/transloco/docs/translation-in-the-template#utilizing-the-prefix-input

The functionality is identical, but support for `read:` will be removed in the next major version.

I tweaked the regex to allow for both syntaxes to work as well as updating the related comment in the code to point to the correct point in the Transloco docs.