### PR TITLE
Update OpenAI Model versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1115,15 +1115,9 @@
           "default": "gpt-3.5-turbo",
           "enum": [
             "gpt-3.5-turbo",
-            "gpt-3.5-turbo-16k",
-            "gpt-3.5-turbo-0301",
-            "gpt-3.5-turbo-0613",
             "gpt-4",
-            "gpt-4-0314",
-            "gpt-4-0613",
-            "gpt-4-32k",
-            "gpt-4-32k-0314",
-            "gpt-4-32k-0613"
+            "gpt-4-turbo",
+            "gpt-4o"
           ],
           "description": "%config.openai_api_model%"
         },


### PR DESCRIPTION
https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4


gpt-4o, gpt-4-turbo, gpt-4, and gpt-3.5-turbo point to their respective latest model version